### PR TITLE
add flask-all-the-things

### DIFF
--- a/kube/patch.sh
+++ b/kube/patch.sh
@@ -29,6 +29,24 @@ spec:
         - \"--stackdriver.kubernetes.location=${GCP_REGION}\"
         - \"--stackdriver.kubernetes.cluster-name=${KUBE_CLUSTER}\"
         - \"--include=kube_deployment_status_replicas_available\"
+        - \"--include=python_gc_objects_collected_total\"
+        - \"--include=python_gc_objects_uncollectable_total\"
+        - \"--include=python_gc_collections_total\"
+        - \"--include=python_info\"
+        - \"--include=process_virtual_memory_bytes\"
+        - \"--include=process_resident_memory_bytes\"
+        - \"--include=process_start_time_seconds\"
+        - \"--include=process_cpu_seconds_total\"
+        - \"--include=process_open_fds\"
+        - \"--include=process_max_fds\"
+        - \"--include=flask_http_request_duration_seconds_bucket\"
+        - \"--include=flask_http_request_duration_seconds_count\"
+        - \"--include=flask_http_request_duration_seconds_sum\"
+        - \"--include=flask_http_request_duration_seconds_created\"
+        - \"--include=flask_http_request_total\"
+        - \"--include=flask_http_request_created\"
+        - \"--include=flask_exporter_info\"
+        - \"--include=app_info\"
         #- \"--stackdriver.generic.location=${GCP_REGION}\"
         #- \"--stackdriver.generic.namespace=${KUBE_CLUSTER}\"
         ports:
@@ -38,3 +56,5 @@ spec:
         - name: ${DATA_VOLUME}
           mountPath: ${DATA_DIR}
 "
+
+


### PR DESCRIPTION
Is this how they should be added? 

I added all here, but I'm assuming we shouldn't send all of them? 

Here's the list that the flask-prometheus-exporter package exposes:

```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 1196.0
python_gc_objects_collected_total{generation="1"} 271.0
python_gc_objects_collected_total{generation="2"} 0.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 102.0
python_gc_collections_total{generation="1"} 9.0
python_gc_collections_total{generation="2"} 0.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="7",patchlevel="5",version="3.7.5"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 4.7689728e+07
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 3.1719424e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.59129784404e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 2.0
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 12.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP flask_http_request_duration_seconds Flask HTTP request duration in seconds
# TYPE flask_http_request_duration_seconds histogram
flask_http_request_duration_seconds_bucket{le="0.005",method="POST",path="/api/v1/recommend",status="200"} 12.0
flask_http_request_duration_seconds_bucket{le="0.01",method="POST",path="/api/v1/recommend",status="200"} 22.0
flask_http_request_duration_seconds_bucket{le="0.025",method="POST",path="/api/v1/recommend",status="200"} 268.0
flask_http_request_duration_seconds_bucket{le="0.05",method="POST",path="/api/v1/recommend",status="200"} 291.0
flask_http_request_duration_seconds_bucket{le="0.075",method="POST",path="/api/v1/recommend",status="200"} 294.0
flask_http_request_duration_seconds_bucket{le="0.1",method="POST",path="/api/v1/recommend",status="200"} 294.0
flask_http_request_duration_seconds_bucket{le="0.25",method="POST",path="/api/v1/recommend",status="200"} 295.0
flask_http_request_duration_seconds_bucket{le="0.5",method="POST",path="/api/v1/recommend",status="200"} 295.0
flask_http_request_duration_seconds_bucket{le="0.75",method="POST",path="/api/v1/recommend",status="200"} 295.0
flask_http_request_duration_seconds_bucket{le="1.0",method="POST",path="/api/v1/recommend",status="200"} 295.0
flask_http_request_duration_seconds_bucket{le="2.5",method="POST",path="/api/v1/recommend",status="200"} 296.0
flask_http_request_duration_seconds_bucket{le="5.0",method="POST",path="/api/v1/recommend",status="200"} 296.0
flask_http_request_duration_seconds_bucket{le="7.5",method="POST",path="/api/v1/recommend",status="200"} 296.0
flask_http_request_duration_seconds_bucket{le="10.0",method="POST",path="/api/v1/recommend",status="200"} 296.0
flask_http_request_duration_seconds_bucket{le="+Inf",method="POST",path="/api/v1/recommend",status="200"} 296.0
flask_http_request_duration_seconds_count{method="POST",path="/api/v1/recommend",status="200"} 296.0
flask_http_request_duration_seconds_sum{method="POST",path="/api/v1/recommend",status="200"} 6.319791500049178
# HELP flask_http_request_duration_seconds_created Flask HTTP request duration in seconds
# TYPE flask_http_request_duration_seconds_created gauge
flask_http_request_duration_seconds_created{method="POST",path="/api/v1/recommend",status="200"} 1.5912978465165179e+09
# HELP flask_http_request_total Total number of HTTP requests
# TYPE flask_http_request_total counter
flask_http_request_total{method="POST",status="200"} 296.0
# HELP flask_http_request_created Total number of HTTP requests
# TYPE flask_http_request_created gauge
flask_http_request_created{method="POST",status="200"} 1.5912978465167162e+09
# HELP flask_exporter_info Information about the Prometheus Flask exporter
# TYPE flask_exporter_info gauge
flask_exporter_info{version="0.13.0"} 1.0
# HELP app_info MyMusic Reco API
# TYPE app_info gauge
app_info 1.0
```